### PR TITLE
Fix `hexToRgbaCss` when alpha is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [1.0.2] - 2022-05-23
-* fixes bug with `hexToRgba` when passed an alpha of 0
+* fixes bug with `hexToRgbaCss` when passed an alpha of 0
 
 ## [1.0.1] - 2020-08-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2022-05-23
+* fixes bug with `hexToRgba` when passed an alpha of 0
+
 ## [1.0.1] - 2020-08-29
 
 ### Fixed

--- a/__tests__/hexToRgbaCss.ts
+++ b/__tests__/hexToRgbaCss.ts
@@ -49,8 +49,10 @@ test('prefixed hex-3', () => {
 })
 
 test('alpha provided', () => {
+  expect(hexToRgbaCss('0099ff80', 0)).toEqual('rgba(0,153,255,0)')
   expect(hexToRgbaCss('0099ff80', 0.3)).toEqual('rgba(0,153,255,0.3)')
   expect(hexToRgbaCss('0099ff', 0.2)).toEqual('rgba(0,153,255,0.2)')
   expect(hexToRgbaCss('09f9', 0.7)).toEqual('rgba(0,153,255,0.7)')
   expect(hexToRgbaCss('09f', 0.45)).toEqual('rgba(0,153,255,0.45)')
+  expect(hexToRgbaCss('0099ff80', 1)).toEqual('rgba(0,153,255,1)')
 })

--- a/__tests__/hexToRgbaCss.ts
+++ b/__tests__/hexToRgbaCss.ts
@@ -49,10 +49,10 @@ test('prefixed hex-3', () => {
 })
 
 test('alpha provided', () => {
-  expect(hexToRgbaCss('0099ff80', 0)).toEqual('rgba(0,153,255,0)')
+  expect(hexToRgbaCss('0099ff', 0)).toEqual('rgba(0,153,255,0)')
   expect(hexToRgbaCss('0099ff80', 0.3)).toEqual('rgba(0,153,255,0.3)')
   expect(hexToRgbaCss('0099ff', 0.2)).toEqual('rgba(0,153,255,0.2)')
   expect(hexToRgbaCss('09f9', 0.7)).toEqual('rgba(0,153,255,0.7)')
   expect(hexToRgbaCss('09f', 0.45)).toEqual('rgba(0,153,255,0.45)')
-  expect(hexToRgbaCss('0099ff80', 1)).toEqual('rgba(0,153,255,1)')
+  expect(hexToRgbaCss('0099ff', 1)).toEqual('rgba(0,153,255,1)')
 })

--- a/source/hexToRgbaCss.ts
+++ b/source/hexToRgbaCss.ts
@@ -8,7 +8,7 @@ export interface HexToRgbaCss {
 
 const hexToRgbaCss: HexToRgbaCss = (str, alpha) => {
   const [r, g, b, _a] = hexToRgba(str)
-  const a = alpha || _a
+  const a = alpha ?? _a
   return rgbaToRgbaCss([r, g, b, a])
 }
 


### PR DESCRIPTION
Fix `hetToRgaCss` when passing an explicit alpha of `0`. Avoids a fasly trap that enoneously passes `undefined` to `rgbaToRgbaCss`.